### PR TITLE
Logout / heartbeat schema bugfix

### DIFF
--- a/man/passwd.md
+++ b/man/passwd.md
@@ -1,4 +1,4 @@
-% FALKOR-AUTH-PASSWD(1) The Falkor Framework **1.0.0** | **Falkor** General Commands Manual % Barnabas Bucsy % October 2021
+% FALKOR-AUTH-PASSWD(1) The Falkor Framework **1.0.0** | **Falkor** General Commands Manual % Barnabas Bucsy % June 2022
 
 # NAME
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@falkor/falkor-auth-server",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falkor/falkor-auth-server",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Nginx authentication server to be used with the Falkor Framework",
   "author": {
     "name": "Barnabas Bucsy",

--- a/readme.md
+++ b/readme.md
@@ -234,4 +234,4 @@ We believe - and we hope you do too - that learning how to code, how to think, a
 
 [MIT](https://github.com/theonethread/falkor-auth-server/blob/master/license.txt "Open")
 
-_©2020-2021 Barnabas Bucsy - All rights reserved._
+_©2020-2022 Barnabas Bucsy - All rights reserved._

--- a/src/route/router.js
+++ b/src/route/router.js
@@ -27,6 +27,15 @@ export default async (config, logger) => {
     const buildSchema = () => {
         const response200 = {
             type: "object",
+            required: ["pid", "id", "status"],
+            properties: {
+                pid: { type: "integer", const: config.pid },
+                id: { type: "string", const: config.id },
+                status: { type: "string", const: defaultSendSuccess.status }
+            }
+        };
+        const response200auth = {
+            type: "object",
             required: ["pid", "id", "status", "user", "role"],
             properties: {
                 pid: { type: "integer", const: config.pid },
@@ -63,11 +72,11 @@ export default async (config, logger) => {
                 response: { 200: response200 }
             },
             validate: {
-                response: { 200: response200, 401: response401 }
+                response: { 200: response200auth, 401: response401 }
             },
             login: {
                 body: bodyLogin,
-                response: { 200: response200, 401: response401 }
+                response: { 200: response200auth, 401: response401 }
             }
         };
     };


### PR DESCRIPTION
## Description
Logout / heartbeat schema bugfix.

## What is the current behavior?
Logout / heartbeat throws 500 internal server error, expecting `user` (and probably `role`) fields in the reply.

## What is the new behavior?
Only login / validate response expects `user` and `role` fields in the reply.

## Does this introduce a breaking change?

* [ ] Yes
* [x] No

## PR Checklist

* [x] Read the [Contribution Guidelines](https://github.com/theonethread/.github/blob/master/.github/contributing.md "Open")
* [x] Code compiles correctly both in `debug` and `release` mode
* [x] Ensured that `npm run prepublishOnly` command generates all necessary release assets
* [x] No new compiler warnings were introduced
* [x] Extended the readme / documentation / CLI help / man file(s) (_where applicable_)
* [x] Dependent changes have been merged and published in downstream modules (_if applicable_)
* [ ] All Continuous Integration builds and security checks pass
